### PR TITLE
small bug and css fixes to admin portal

### DIFF
--- a/less/admin.less
+++ b/less/admin.less
@@ -98,6 +98,7 @@ tbody{
 }
 .recipe-url{
     max-width: 500px;;
+    overflow: scroll;
 }
 .recipe-name{
     max-width: 200px;;

--- a/public/index.css
+++ b/public/index.css
@@ -1079,6 +1079,7 @@ tbody {
 }
 .recipe-url {
   max-width: 500px;
+  overflow: scroll;
 }
 .recipe-name {
   max-width: 200px;

--- a/src/components/admin/AddRecipe.jsx
+++ b/src/components/admin/AddRecipe.jsx
@@ -70,7 +70,7 @@ const AddRecipeAdminPage = () => {
 			})
 		);
 
-		navigate('/adminportal');
+		navigate('/admin/recipes?page=1');
 		toast.success(`New recipe added: "${form.name}"`, {
 			position: 'bottom-right',
 			autoClose: 2000,
@@ -256,7 +256,7 @@ const AddRecipeAdminPage = () => {
 								<option value="" disabled selected>
 									Cuisine
 								</option>
-								{cuisines.map((ele, index) => (
+								{cuisines.filter(tag => tag !== 'all').map((ele, index) => (
 									<option value={ele} key={index}>
 										{ele.length ? ele[0].toUpperCase() + ele.slice(1) : ''}
 									</option>
@@ -279,7 +279,7 @@ const AddRecipeAdminPage = () => {
 								<option value="" disabled selected>
 									Optional
 								</option>
-								{restrictions.map((ele, index) => (
+								{restrictions.filter(tag => tag !== 'all').map((ele, index) => (
 									<option value={ele} key={index}>
 										{ele.length ? ele[0].toUpperCase() + ele.slice(1) : ''}
 									</option>
@@ -349,7 +349,6 @@ const AddRecipeAdminPage = () => {
 							className={checkDisabled() ? 'navbutton disabled' : 'navbutton'}
 							type="submit"
 							disabled={checkDisabled()}
-							onClick={handleSubmit}
 						>
 							Add Recipe
 						</button>

--- a/src/components/admin/ModifyRecipe.jsx
+++ b/src/components/admin/ModifyRecipe.jsx
@@ -252,6 +252,7 @@ const ModifyRecipeAdminPage = () => {
                                         className="textBox"
                                         placeholder="Recipe Url"
                                         name="url"
+                                        type="url"
                                         value={form.url}
                                         onChange={handleChange("url")}
                                     />
@@ -267,6 +268,7 @@ const ModifyRecipeAdminPage = () => {
                                         className="textBox"
                                         placeholder="Recipe Image Url"
                                         name="img"
+                                        type="url"
                                         value={form.img}
                                         onChange={handleChange("img")}
                                     />

--- a/src/components/admin/Recipes.jsx
+++ b/src/components/admin/Recipes.jsx
@@ -25,6 +25,13 @@ const AllRecipesAdminPage = () => {
 
 	const statuses = ['both', 'yes', 'no'];
 
+	// addresses bug where if admin clicks on 'Recipes' tab when page != 1, table would not update
+	useEffect(() => {
+		if (Number(page) !== Number(searchParams.get('page'))) {
+			setPage(searchParams.get('page'))
+		}
+	},[searchParams.get('page')])
+
 	useEffect(() => {
 		const token = window.localStorage.getItem('token');
 		if ((user.isLogged && !user.isAdmin) || !token) {
@@ -70,7 +77,6 @@ const AllRecipesAdminPage = () => {
 	};
 
 	return (
-		// recipes.length > 0 ?
 		recipeStatus === 'succeeded' ? (
 			<div className="all-recipes-container">
 				<div className="allrecipes-header">
@@ -126,6 +132,7 @@ const AllRecipesAdminPage = () => {
 									Number(page) === 1 ? 'prevNext disabled' : 'prevNext'
 								}
 								onClick={() => setPage(+page - 1)}
+									
 							>
 								Prev
 							</Link>

--- a/src/components/admin/Recipes.jsx
+++ b/src/components/admin/Recipes.jsx
@@ -131,8 +131,7 @@ const AllRecipesAdminPage = () => {
 								className={
 									Number(page) === 1 ? 'prevNext disabled' : 'prevNext'
 								}
-								onClick={() => setPage(+page - 1)}
-									
+								onClick={() => setPage(+page - 1)}		
 							>
 								Prev
 							</Link>

--- a/src/components/routes/Routes.jsx
+++ b/src/components/routes/Routes.jsx
@@ -52,7 +52,6 @@ const RoutesComponent = () => {
 				<Route path="updaterecipe/:id" element={<ModifyRecipeAdminPage />} />
 				<Route path="*" element={<NotFound />} />
 			</Route>
-			{/* <Route path="user/chefschoice" element={<ChefsChoice />} /> */}
 			<Route path="map" element={<MapMain />} />
 			<Route path="*" element={<NotFound />} />
 		</Routes>


### PR DESCRIPTION
- fixed url overflow issue on admin recipes page
- fixed routing bug when adding new recipe (routed to an old route '/adminportal' which no longer exists)
- fixed bug on admin all recipes page where if the url param page was not 1 and user clicks on the 'Recipes' tab again, url page would get set to 1 but recipes in table would not update
- fixed form validation for URL's in add recipe page; added type='url' to modify recipe page as well